### PR TITLE
Allow lowercase to be an entry for node names

### DIFF
--- a/lib/convertNodeNamesToHex.js
+++ b/lib/convertNodeNamesToHex.js
@@ -9,6 +9,7 @@ var csvWriter = require('csv-write-stream')
 
 const ORIGINAL_NODE_HEADER = 'Summary of Original Node';
 const MUTATED_NODE_HEADER = 'Summary of Mutated Node';
+
 var writer = csvWriter({ headers: ['Original Node', 'Original Node in HEX', 'Mutated Node', 'Mutated Node in HEX']});
 writer.pipe(fs.createWriteStream('data/node-names-hex.csv'));
 

--- a/lib/utils/convertStringToHex.js
+++ b/lib/utils/convertStringToHex.js
@@ -1,8 +1,12 @@
 var SYMBOL_HEX_MAP = {
   'T': 'e296bc',
+  't': 'e296bc',
   'D': 'e299a6',
+  'd': 'e299a6',
   'S': 'e296a0',
+  's': 'e296a0',
   'C': 'e2978f',
+  'c': 'e2978f',
   ' ': '' //making sure spaces don't break our data
 };
 module.exports = (string) => {


### PR DESCRIPTION
`undefined` would be the output of Node names with lowercase characters. This makes sure we tolerate entries with lowercase.
